### PR TITLE
Relax version definitions for actions in github actions.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v4.1.0
+        uses: crazy-max/ghaction-github-labeler@v4
         with:
           skip-delete: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -39,7 +39,7 @@ jobs:
       - name: Detect and tag new version
         id: check-version
         if: steps.check-parent-commit.outputs.sha
-        uses: salsify/action-detect-and-tag-new-version@v2.0.3
+        uses: salsify/action-detect-and-tag-new-version@v2
         with:
           version-command: |
             bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
@@ -56,7 +56,7 @@ jobs:
           poetry build --ansi
 
       - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5.21.1
+        uses: release-drafter/release-drafter@v5
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4.3.1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -72,7 +72,7 @@ jobs:
           print("::set-output name=result::{}".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v3.1.1"
+        uses: "actions/upload-artifact@v3
         with:
           name: coverage-data
           path: ".coverage.*"
@@ -96,10 +96,10 @@ jobs:
     needs: tests
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -120,7 +120,7 @@ jobs:
           nox --version
 
       - name: Download coverage data
-        uses: actions/download-artifact@v3.0.1
+        uses: actions/download-artifact@v3
         with:
           name: coverage-data
 
@@ -133,4 +133,4 @@ jobs:
           nox --force-color --session=coverage -- xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reference major versions instead of specific versions. This is in the same spirit as using >= instead of ^ or ~ for specifying package dependencies.